### PR TITLE
Issue 437

### DIFF
--- a/SqlWatch.Monitor/Project.SqlWatch.Database/dbo/Tables/sqlwatch_logger_xes_query_processing.sql
+++ b/SqlWatch.Monitor/Project.SqlWatch.Database/dbo/Tables/sqlwatch_logger_xes_query_processing.sql
@@ -20,5 +20,6 @@
 go
 
 create unique nonclustered index idx_sqlwatch_xes_query_processing_event_time
-	on [dbo].[sqlwatch_logger_xes_query_processing] ([event_time]);
+	on [dbo].[sqlwatch_logger_xes_query_processing] ([event_time]),
+	   [dbo].[sqlwatch_logger_xes_query_processing] ([sql_instance]);
 go


### PR DESCRIPTION
See https://github.com/marcingminski/sqlwatch/issues/437 . Duplicate key will be found if 2 instances have an event_time at exactly the same time (in 0.001 second).