### PR TITLE
Issue #437

### DIFF
--- a/SqlWatch.Monitor/Project.SqlWatch.Database/dbo/Tables/sqlwatch_logger_xes_iosubsystem.sql
+++ b/SqlWatch.Monitor/Project.SqlWatch.Database/dbo/Tables/sqlwatch_logger_xes_iosubsystem.sql
@@ -18,5 +18,6 @@
 go
 
 create unique nonclustered index idx_sqlwatch_xes_iosubsystem_event_time
-	on [dbo].[sqlwatch_logger_xes_iosubsystem] ([event_time]);
+	on [dbo].[sqlwatch_logger_xes_iosubsystem] ([event_time]),
+	   [dbo].[sqlwatch_logger_xes_iosubsystem] ([sql_instance]);
 go


### PR DESCRIPTION
See https://github.com/marcingminski/sqlwatch/issues/437 . Duplicate key will be found if 2 instances have an event_time at exactly the same time (in 0.001 second).